### PR TITLE
disable debug mode for release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,10 +71,8 @@ VARIANT_PARAM = COIN
 VARIANT_VALUES = ontology
 
 # Enabling DEBUG flag will enable PRINTF and disable optimizations
-DEBUG = 1
+#DEBUG = 1
 
-#APP_LOAD_PARAMS = --appFlags 0x240
-#APPFLAGS = 0x240
 ########################################
 #     Application custom permissions   #
 ########################################


### PR DESCRIPTION
build: disable debug mode for production

Commented out DEBUG = 1 in Makefile to disable debug logging and assertions
for the release build. This reduces binary size and removes debug symbols.